### PR TITLE
fix polygon_crossing issue with collinear edge

### DIFF
--- a/pyvisgraph/visible_vertices.py
+++ b/pyvisgraph/visible_vertices.py
@@ -129,6 +129,7 @@ def polygon_crossing(p1, poly_edges):
         co0 = (ccw(p1, edge.p1, p2) == 0) and (edge.p1.x > p1.x)
         co1 = (ccw(p1, edge.p2, p2) == 0) and (edge.p2.x > p1.x)
         co_point = edge.p1 if co0 else edge.p2
+        if co0 and co1: continue
         if co0 or co1:
             if edge.get_adjacent(co_point).y > p1.y:
                 co_dir += 1

--- a/pyvisgraph/visible_vertices.py
+++ b/pyvisgraph/visible_vertices.py
@@ -288,7 +288,8 @@ def angle2(point_a, point_b, point_c):
     a = (point_c.x - point_b.x)**2 + (point_c.y - point_b.y)**2
     b = (point_c.x - point_a.x)**2 + (point_c.y - point_a.y)**2
     c = (point_b.x - point_a.x)**2 + (point_b.y - point_a.y)**2
-    return acos((a + c - b) / (2 * sqrt(a) * sqrt(c)))
+    cos_value = (a + c - b) / (2 * sqrt(a) * sqrt(c))
+    return acos( max(-1, min(1, cos_value)) )
 
 
 def ccw(A, B, C):


### PR DESCRIPTION
I found some cases where polygon_crossing() misses to label some edges as not visible.
The code bellow is an example of failure case before the fix.

I'm not totally sure, but my investigations lead me to conclude that this (co0 and co1) case in polygon_crossing() can solve that out.

```python
import pyvisgraph as vg

# Set obstacles
obstacles = [
    [
        vg.Point(200.00, 50.00),
        vg.Point(200.00, 100.00),
        vg.Point(700.00, 100.00),
        vg.Point(700.00, 50.00)
    ], [
        vg.Point(4.00, 200.00),
        vg.Point(600.00, 200.00),
        vg.Point(600.00, 150.00),
        vg.Point(4.00, 150.00),
        vg.Point(4.00, 0.00),
        vg.Point(0.00, 0.00),
        vg.Point(0.00, 150.00),
        vg.Point(0.00, 200.00),
        vg.Point(0.00, 800.00),
        vg.Point(4.00, 800.00)
    ]
]

# Build path showing issue with polygon_crossing function
g = vg.VisGraph()
g.build(obstacles)
path = g.shortest_path(vg.Point(50, 400), vg.Point(50, 20))
print(path)
print("The edge from Point(0.00, 150.00) to Point(4.00, 150.00) outputed is wrong")

# Display with pygame
import pygame, time, sys

pygame.init()
screen = pygame.display.set_mode((800, 800))
screen.fill(0xFFFFFF)
for poly in obstacles:
    pygame.draw.polygon(screen, 0x000000, [(p.x, p.y) for p in poly])
pygame.draw.lines(screen, 0xFF0000, False, [(p.x, p.y) for p in path], 2)
pygame.display.update()
while True:
    for event in pygame.event.get():
        if event.type == pygame.QUIT:
            sys.exit(0)
    time.sleep(0.1)
```