### PR TITLE
bugfix: handle problems acos arg > 1

### DIFF
--- a/pyvisgraph/visible_vertices.py
+++ b/pyvisgraph/visible_vertices.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 from __future__ import division
-from math import pi, sqrt, atan, acos
+from math import pi, sqrt, atan, acos, fabs
 from pyvisgraph.graph import Point
 
 INF = 10000
@@ -289,7 +289,24 @@ def angle2(point_a, point_b, point_c):
     b = (point_c.x - point_a.x)**2 + (point_c.y - point_a.y)**2
     c = (point_b.x - point_a.x)**2 + (point_b.y - point_a.y)**2
     cos_value = (a + c - b) / (2 * sqrt(a) * sqrt(c))
-    return acos(int(cos_value*T)/T2)
+    interior  = int(cos_value*T)/T2
+
+    # In some cases interior was above 1 due to floating point
+    # problems.
+    try:
+        return acos(interior)
+    except:
+        if isclose(interior, 1):
+            return 0
+        elif isclose(isclose, -1):
+            return pi
+        else:
+            raise
+
+
+def isclose(a, b, rtol=1e-05, atol=1e-08):
+    '''Implemented numpy.isclose to avoid the numpy dependency'''
+    return fabs(a-b) <= (atol + rtol * fabs(b))
 
 
 def ccw(A, B, C):


### PR DESCRIPTION
While processing the shoreline set GSHHS_c_L1 with 742 shapes a
problem was encountered where cos_value = 1.00000000000048 which meant
that the acos raised an ValueError: math domain error and the graph
could not be built.

This patch checks if the arguments are very close to -1 or 1 and returns
the expected values. If the values are not close to either of these
values the ValueError is still raised.

Examples of values in angle2 when problem was first encountered:
point_a   = (112.96, -25.49)
point_b   = (45.00, -25.49)
point_c   = (45.00, -25.49)
a         = 6.938890000001394e-07
b         = 4618.002849783456
c         = 4618.11606498842
cos_value = 1.00000000000048
T         = 10000000000000
T2        = 10000000000000.0